### PR TITLE
Add banned word CRUD module

### DIFF
--- a/bossbot/src/main/java/com/example/bossbot/bannedword/controller/BannedWordController.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/controller/BannedWordController.java
@@ -1,0 +1,106 @@
+package com.example.bossbot.bannedword.controller;
+
+import com.example.bossbot.bannedword.dto.BannedWordResponse;
+import com.example.bossbot.bannedword.dto.CreateBannedWordRequest;
+import com.example.bossbot.bannedword.dto.UpdateBannedWordRequest;
+import com.example.bossbot.bannedword.service.BannedWordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/banned-words")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Banned Words", description = "Banned word management operations")
+public class BannedWordController {
+
+    private final BannedWordService bannedWordService;
+
+    @Operation(summary = "Create a new banned word")
+    @ApiResponse(responseCode = "201", description = "Banned word created successfully")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @PostMapping
+    public ResponseEntity<BannedWordResponse> create(@Valid @RequestBody CreateBannedWordRequest request) {
+        log.info("REST request to create banned word");
+        BannedWordResponse response = bannedWordService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "Get banned word by ID")
+    @ApiResponse(responseCode = "200", description = "Banned word found")
+    @ApiResponse(responseCode = "404", description = "Banned word not found")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @GetMapping("/{id}")
+    public ResponseEntity<BannedWordResponse> getById(@PathVariable Long id) {
+        log.info("REST request to get banned word by ID: {}", id);
+        BannedWordResponse response = bannedWordService.getById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Get all banned words")
+    @ApiResponse(responseCode = "200", description = "Banned words returned")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @GetMapping
+    public ResponseEntity<List<BannedWordResponse>> getAll(
+            @RequestParam(required = false, defaultValue = "false") boolean activeOnly) {
+        log.info("REST request to get all banned words. Active only: {}", activeOnly);
+        List<BannedWordResponse> responses = activeOnly
+                ? bannedWordService.getAllActive()
+                : bannedWordService.getAll();
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "Get banned words by category")
+    @ApiResponse(responseCode = "200", description = "Banned words returned")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @GetMapping("/category/{category}")
+    public ResponseEntity<List<BannedWordResponse>> getByCategory(@PathVariable String category) {
+        log.info("REST request to get banned words by category: {}", category);
+        List<BannedWordResponse> responses = bannedWordService.getByCategory(category);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "Update a banned word")
+    @ApiResponse(responseCode = "200", description = "Banned word updated successfully")
+    @ApiResponse(responseCode = "404", description = "Banned word not found")
+    @ApiResponse(responseCode = "400", description = "Invalid request body")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @PutMapping("/{id}")
+    public ResponseEntity<BannedWordResponse> update(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateBannedWordRequest request) {
+        log.info("REST request to update banned word with ID: {}", id);
+        BannedWordResponse response = bannedWordService.update(id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Delete (deactivate) a banned word")
+    @ApiResponse(responseCode = "204", description = "Banned word deleted successfully")
+    @ApiResponse(responseCode = "404", description = "Banned word not found")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        log.info("REST request to delete banned word with ID: {}", id);
+        bannedWordService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.error("Validation error: {}", ex.getMessage());
+        ErrorResponse error = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    public record ErrorResponse(String message) {}
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/dto/BannedWordResponse.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/dto/BannedWordResponse.java
@@ -1,0 +1,40 @@
+package com.example.bossbot.bannedword.dto;
+
+import com.example.bossbot.bannedword.entity.BannedWord;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BannedWordResponse {
+
+    private Long id;
+    private String word;
+    private String category;
+    private String severity;
+    private Boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long createdBy;
+    private Long updatedBy;
+
+    public static BannedWordResponse fromEntity(BannedWord entity) {
+        return BannedWordResponse.builder()
+                .id(entity.getId())
+                .word(entity.getWord())
+                .category(entity.getCategory())
+                .severity(entity.getSeverity())
+                .isActive(entity.getIsActive())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .createdBy(entity.getCreatedBy())
+                .updatedBy(entity.getUpdatedBy())
+                .build();
+    }
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/dto/CreateBannedWordRequest.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/dto/CreateBannedWordRequest.java
@@ -1,0 +1,24 @@
+package com.example.bossbot.bannedword.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateBannedWordRequest {
+
+    @NotBlank(message = "Word is required")
+    private String word;
+
+    private String category;
+
+    private String severity;
+
+    @Builder.Default
+    private Boolean isActive = true;
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/dto/UpdateBannedWordRequest.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/dto/UpdateBannedWordRequest.java
@@ -1,0 +1,21 @@
+package com.example.bossbot.bannedword.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateBannedWordRequest {
+
+    private String word;
+
+    private String category;
+
+    private String severity;
+
+    private Boolean isActive;
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/entity/BannedWord.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/entity/BannedWord.java
@@ -1,0 +1,49 @@
+package com.example.bossbot.bannedword.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "banned_words")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BannedWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String word;
+
+    @Column(length = 50)
+    private String category;
+
+    @Column(length = 20)
+    private String severity;
+
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "created_by", nullable = false, updatable = false)
+    private Long createdBy;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/repository/BannedWordRepository.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/repository/BannedWordRepository.java
@@ -1,0 +1,20 @@
+package com.example.bossbot.bannedword.repository;
+
+import com.example.bossbot.bannedword.entity.BannedWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BannedWordRepository extends JpaRepository<BannedWord, Long> {
+
+    List<BannedWord> findByIsActiveTrue();
+
+    List<BannedWord> findByCategoryAndIsActiveTrue(String category);
+
+    Optional<BannedWord> findByWordIgnoreCaseAndIsActiveTrue(String word);
+
+    boolean existsByWordIgnoreCase(String word);
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/service/BannedWordService.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/service/BannedWordService.java
@@ -1,0 +1,24 @@
+package com.example.bossbot.bannedword.service;
+
+import com.example.bossbot.bannedword.dto.BannedWordResponse;
+import com.example.bossbot.bannedword.dto.CreateBannedWordRequest;
+import com.example.bossbot.bannedword.dto.UpdateBannedWordRequest;
+
+import java.util.List;
+
+public interface BannedWordService {
+
+    BannedWordResponse create(CreateBannedWordRequest request);
+
+    BannedWordResponse getById(Long id);
+
+    List<BannedWordResponse> getAll();
+
+    List<BannedWordResponse> getAllActive();
+
+    List<BannedWordResponse> getByCategory(String category);
+
+    BannedWordResponse update(Long id, UpdateBannedWordRequest request);
+
+    void delete(Long id);
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/service/BannedWordServiceImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/service/BannedWordServiceImpl.java
@@ -1,0 +1,134 @@
+package com.example.bossbot.bannedword.service;
+
+import com.example.bossbot.bannedword.dto.BannedWordResponse;
+import com.example.bossbot.bannedword.dto.CreateBannedWordRequest;
+import com.example.bossbot.bannedword.dto.UpdateBannedWordRequest;
+import com.example.bossbot.bannedword.entity.BannedWord;
+import com.example.bossbot.bannedword.repository.BannedWordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BannedWordServiceImpl implements BannedWordService {
+
+    private static final String BANNED_WORD_NOT_FOUND = "Banned word not found with ID: ";
+
+    private final BannedWordRepository repository;
+
+    @Override
+    @Transactional
+    public BannedWordResponse create(CreateBannedWordRequest request) {
+        log.info("Creating new banned word: {}", request.getWord());
+
+        if (repository.existsByWordIgnoreCase(request.getWord())) {
+            throw new IllegalArgumentException("Banned word already exists");
+        }
+
+        Long currentUserId = 1L; // placeholder until Spring Security
+
+        BannedWord entity = BannedWord.builder()
+                .word(request.getWord())
+                .category(request.getCategory())
+                .severity(request.getSeverity())
+                .isActive(request.getIsActive() != null ? request.getIsActive() : Boolean.TRUE)
+                .createdBy(currentUserId)
+                .build();
+
+        BannedWord saved = repository.save(entity);
+        log.info("Created banned word with ID: {}", saved.getId());
+
+        return BannedWordResponse.fromEntity(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BannedWordResponse getById(Long id) {
+        log.info("Fetching banned word with ID: {}", id);
+
+        BannedWord entity = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException(BANNED_WORD_NOT_FOUND + id));
+
+        return BannedWordResponse.fromEntity(entity);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BannedWordResponse> getAll() {
+        log.info("Fetching all banned words");
+
+        return repository.findAll().stream()
+                .map(BannedWordResponse::fromEntity)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BannedWordResponse> getAllActive() {
+        log.info("Fetching all active banned words");
+
+        return repository.findByIsActiveTrue().stream()
+                .map(BannedWordResponse::fromEntity)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BannedWordResponse> getByCategory(String category) {
+        log.info("Fetching banned words by category: {}", category);
+
+        return repository.findByCategoryAndIsActiveTrue(category).stream()
+                .map(BannedWordResponse::fromEntity)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public BannedWordResponse update(Long id, UpdateBannedWordRequest request) {
+        log.info("Updating banned word with ID: {}", id);
+
+        BannedWord entity = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException(BANNED_WORD_NOT_FOUND + id));
+
+        Long currentUserId = 1L; // placeholder until Spring Security
+
+        if (request.getWord() != null) {
+            entity.setWord(request.getWord());
+        }
+        if (request.getCategory() != null) {
+            entity.setCategory(request.getCategory());
+        }
+        if (request.getSeverity() != null) {
+            entity.setSeverity(request.getSeverity());
+        }
+        if (request.getIsActive() != null) {
+            entity.setIsActive(request.getIsActive());
+        }
+
+        entity.setUpdatedBy(currentUserId);
+
+        BannedWord updated = repository.save(entity);
+        log.info("Updated banned word with ID: {}", id);
+
+        return BannedWordResponse.fromEntity(updated);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long id) {
+        log.info("Soft deleting banned word with ID: {}", id);
+
+        BannedWord entity = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException(BANNED_WORD_NOT_FOUND + id));
+
+        entity.setIsActive(false);
+        repository.save(entity);
+
+        log.info("Soft deleted banned word with ID: {}", id);
+    }
+}


### PR DESCRIPTION
Add banned word CRUD functionality using Spring Boot and Hibernate.

Includes:
- BannedWord entity with Hibernate mapping
- Repository, service and controller layers
- DTOs for create/update/response
- CRUD endpoints with soft delete (isActive)
- Category and active filtering support

Database:
- Table created via Hibernate (ddl-auto=update)

Notes:
- createdBy / updatedBy use placeholder values for now; will be linked to User entity after authentication is implemented