### PR TITLE
Bugfix - merge conflict + stamp answer ambiguity threshold

### DIFF
--- a/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
+++ b/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
@@ -165,6 +165,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         }
 
         return false;
+    }
     @PreDestroy
     void shutdown() {
         executor.shutdown();

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/config/StampMatcherConfig.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/config/StampMatcherConfig.java
@@ -12,4 +12,5 @@ public class StampMatcherConfig {
     private double similarityThreshold = 0.7;
     private double keywordThreshold = 0.3;
     private int minInputLength = 3;
+    private double ambiguityThreshold = 0.1;
 }

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordMatchUtils.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordMatchUtils.java
@@ -10,7 +10,7 @@ final class KeywordMatchUtils {
     private KeywordMatchUtils() {
     }
 
-    static Optional<StampAnswer> findBestKeywordMatch(String input, List<StampAnswer> stampAnswers, int minInputLength, double keywordThreshold) {
+    static Optional<StampAnswer> findBestKeywordMatch(String input, List<StampAnswer> stampAnswers, int minInputLength, double keywordThreshold, double ambiguityThreshold) {
         if (input == null || input.trim().length() < minInputLength) {
             return Optional.empty();
         }
@@ -22,6 +22,7 @@ final class KeywordMatchUtils {
 
         StampAnswer bestMatch = null;
         double bestScore = 0;
+        double secondBestScore = 0;
 
         for (StampAnswer sa : stampAnswers) {
             Set<String> answerWords = tokenize(sa.getQuestion());
@@ -36,13 +37,16 @@ final class KeywordMatchUtils {
             long unionSize = inputWords.size() + answerWords.size() - matchCount;
             double score = unionSize == 0 ? 0.0 : (double) matchCount / unionSize;
 
-            if (score > bestScore || (score == bestScore && bestMatch != null && sa.getPriority() > bestMatch.getPriority())) {
+            if (score > bestScore) {
+                secondBestScore = bestScore;
                 bestScore = score;
                 bestMatch = sa;
+            } else if (score > secondBestScore) {
+                secondBestScore = score;
             }
         }
 
-        if (bestScore >= keywordThreshold) {
+        if (bestScore >= keywordThreshold && (bestScore - secondBestScore) >= ambiguityThreshold) {
             return Optional.of(bestMatch);
         }
         return Optional.empty();

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImpl.java
@@ -31,13 +31,13 @@ public class KeywordStampMatcherImpl implements StampMatcherService {
 
     @Override
     public void refreshCache() {
-        cache.set(List.copyOf(repository.findByIsActiveTrueOrderByPriorityDesc()));
+        cache.set(List.copyOf(repository.findByIsActiveTrueOrderByCreatedAtDesc()));
         log.info("Keyword stamp matcher cache refreshed ({} entries)", cache.get().size());
     }
 
     @Override
     public Optional<StampAnswerResponse> findBestMatch(String userInput) {
-        return KeywordMatchUtils.findBestKeywordMatch(userInput, cache.get(), config.getMinInputLength(), config.getKeywordThreshold())
+        return KeywordMatchUtils.findBestKeywordMatch(userInput, cache.get(), config.getMinInputLength(), config.getKeywordThreshold(), config.getAmbiguityThreshold())
                 .map(StampAnswerResponse::fromEntity);
     }
 }

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImpl.java
@@ -41,7 +41,7 @@ public class OllamaStampMatcherImpl implements StampMatcherService {
 
     @Override
     public void refreshCache() {
-        List<StampAnswer> active = repository.findByIsActiveTrueOrderByPriorityDesc();
+        List<StampAnswer> active = repository.findByIsActiveTrueOrderByCreatedAtDesc();
 
         if (active.isEmpty()) {
             cache.set(List.of());
@@ -109,30 +109,39 @@ public class OllamaStampMatcherImpl implements StampMatcherService {
 
             StampAnswer bestMatch = null;
             double bestSimilarity = 0;
+            double secondBestSimilarity = 0;
 
             for (StampAnswerEmbedding entry : entries) {
                 if (entry.embedding() == null) continue;
                 double similarity = cosineSimilarity(inputEmbedding, entry.embedding());
-                if (similarity > bestSimilarity ||
-                        (similarity == bestSimilarity && bestMatch != null
-                                && entry.stampAnswer().getPriority() > bestMatch.getPriority())) {
+                if (similarity > bestSimilarity) {
+                    secondBestSimilarity = bestSimilarity;
                     bestSimilarity = similarity;
                     bestMatch = entry.stampAnswer();
+                } else if (similarity > secondBestSimilarity) {
+                    secondBestSimilarity = similarity;
                 }
             }
 
-            if (bestSimilarity >= config.getSimilarityThreshold() && bestMatch != null) {
-                log.info("Semantic match found (similarity={}) for input: {}", bestSimilarity, userInput);
+            if (bestSimilarity >= config.getSimilarityThreshold() && bestMatch != null
+                    && (bestSimilarity - secondBestSimilarity) >= config.getAmbiguityThreshold()) {
+                log.info("Semantic match found (similarity={}, gap={}) for input: {}",
+                        bestSimilarity, bestSimilarity - secondBestSimilarity, userInput);
                 return Optional.of(StampAnswerResponse.fromEntity(bestMatch));
             }
 
-            log.debug("No semantic match above threshold {} for input: {}", config.getSimilarityThreshold(), userInput);
+            if (bestSimilarity >= config.getSimilarityThreshold() && bestMatch != null) {
+                log.info("Ambiguous match rejected (similarity={}, gap={}) for input: {}",
+                        bestSimilarity, bestSimilarity - secondBestSimilarity, userInput);
+            } else {
+                log.debug("No semantic match above threshold {} for input: {}", config.getSimilarityThreshold(), userInput);
+            }
             return Optional.empty();
 
         } catch (OllamaException e) {
             log.warn("Ollama unavailable at runtime, falling back to keyword matching: {}", e.getMessage());
             List<StampAnswer> stampAnswers = entries.stream().map(StampAnswerEmbedding::stampAnswer).toList();
-            return KeywordMatchUtils.findBestKeywordMatch(userInput, stampAnswers, config.getMinInputLength(), config.getKeywordThreshold())
+            return KeywordMatchUtils.findBestKeywordMatch(userInput, stampAnswers, config.getMinInputLength(), config.getKeywordThreshold(), config.getAmbiguityThreshold())
                     .map(StampAnswerResponse::fromEntity);
         }
     }

--- a/bossbot/src/main/resources/application.properties
+++ b/bossbot/src/main/resources/application.properties
@@ -40,6 +40,7 @@ ollama.chat-model=${OLLAMA_CHAT_MODEL:llama3.2:3b}
 stamp-matcher.similarity-threshold=${STAMP_MATCHER_SIMILARITY_THRESHOLD:0.7}
 stamp-matcher.keyword-threshold=${STAMP_MATCHER_KEYWORD_THRESHOLD:0.3}
 stamp-matcher.min-input-length=${STAMP_MATCHER_MIN_INPUT_LENGTH:3}
+stamp-matcher.ambiguity-threshold=${STAMP_MATCHER_AMBIGUITY_THRESHOLD:0.1}
 
 # Liquibase logging (set to DEBUG for troubleshooting)
 logging.level.liquibase=INFO

--- a/bossbot/src/test/java/com/example/bossbot/chat/handler/ChatWebSocketHandlerTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/chat/handler/ChatWebSocketHandlerTest.java
@@ -58,13 +58,11 @@ class ChatWebSocketHandlerTest {
         // Given — connection established
         handler.afterConnectionEstablished(session);
 
-        // When — send 3 messages (burst count = 3)
+        // When — send 3 messages (burst count = 3), waiting for each to complete on the executor
         for (int i = 0; i < 3; i++) {
             handler.handleTextMessage(session, createMessage(1L, "Hello " + i));
+            verify(chatService, timeout(1000).times(i + 1)).processMessage(eq(1L), any(), any(), any());
         }
-
-        // Then — all 3 should reach the chat service
-        verify(chatService, times(3)).processMessage(eq(1L), any(), any());
     }
 
     @Test
@@ -73,19 +71,17 @@ class ChatWebSocketHandlerTest {
         // Given
         handler.afterConnectionEstablished(session);
 
-        // When — send 4 messages rapidly (burst = 3, so 4th triggers cooldown on 5th)
+        // When — send 4 messages (burst = 3, so 4th triggers cooldown on 5th)
         for (int i = 0; i < 4; i++) {
             handler.handleTextMessage(session, createMessage(1L, "Msg " + i));
+            verify(chatService, timeout(1000).times(i + 1)).processMessage(eq(1L), any(), any(), any());
         }
-
-        // The 4th message goes through but sets cooldown
-        verify(chatService, times(4)).processMessage(eq(1L), any(), any());
 
         // 5th message should be rate limited
         handler.handleTextMessage(session, createMessage(1L, "Msg 5"));
 
         // Still only 4 calls to chatService
-        verify(chatService, times(4)).processMessage(eq(1L), any(), any());
+        verify(chatService, times(4)).processMessage(eq(1L), any(), any(), any());
 
         // Verify a RATE_LIMITED response was sent
         ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
@@ -105,6 +101,7 @@ class ChatWebSocketHandlerTest {
         // Burst of 3 goes through, 4th goes through but sets cooldown at 1000ms
         for (int i = 0; i < 4; i++) {
             handler.handleTextMessage(session, createMessage(1L, "Msg " + i));
+            verify(chatService, timeout(1000).times(i + 1)).processMessage(eq(1L), any(), any(), any());
         }
 
         // 5th message is rate limited (cooldown = 1000ms)
@@ -130,6 +127,7 @@ class ChatWebSocketHandlerTest {
         handler.afterConnectionEstablished(session);
         for (int i = 0; i < 4; i++) {
             handler.handleTextMessage(session, createMessage(1L, "Msg " + i));
+            verify(chatService, timeout(1000).times(i + 1)).processMessage(eq(1L), any(), any(), any());
         }
 
         // When — disconnect and reconnect
@@ -139,10 +137,8 @@ class ChatWebSocketHandlerTest {
         // Then — burst count resets, messages go through again
         for (int i = 0; i < 3; i++) {
             handler.handleTextMessage(session, createMessage(1L, "After reconnect " + i));
+            verify(chatService, timeout(1000).times(4 + i + 1)).processMessage(eq(1L), any(), any(), any());
         }
-
-        // 4 before disconnect + 3 after reconnect = 7 total
-        verify(chatService, times(7)).processMessage(eq(1L), any(), any());
     }
 
     @Test

--- a/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordMatchUtilsTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordMatchUtilsTest.java
@@ -14,13 +14,13 @@ class KeywordMatchUtilsTest {
 
     private static final int MIN_INPUT_LENGTH = 3;
     private static final double KEYWORD_THRESHOLD = 0.3;
+    private static final double AMBIGUITY_THRESHOLD = 0.1;
 
-    private StampAnswer buildStampAnswer(Long id, String question, String keywords, int priority) {
+    private StampAnswer buildStampAnswer(Long id, String question, String keywords) {
         return StampAnswer.builder()
                 .id(id)
                 .question(question)
                 .keywords(keywords)
-                .priority(priority)
                 .isActive(true)
                 .build();
     }
@@ -28,40 +28,40 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return empty for single letter input")
     void testSingleLetter_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("k", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("k", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("Should return empty for two character input")
     void testTwoCharInput_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("hi", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("hi", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("Should return empty for null input")
     void testNullInput_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch(null, List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch(null, List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("Should return empty for blank input")
     void testBlankInput_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("   ", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("   ", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("Should return match when input has good word overlap")
     void testGoodOverlap_returnsMatch() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot, framework", 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring Boot", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot, framework");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring Boot", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(1L);
     }
@@ -69,8 +69,8 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return match when input matches keywords")
     void testMatchesKeywords() {
-        StampAnswer sa = buildStampAnswer(1L, "opening hours question", "hours, schedule, time", 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("schedule time", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "opening hours question", "hours, schedule, time");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("schedule time", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(1L);
     }
@@ -78,33 +78,42 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return empty when word overlap is too low")
     void testLowOverlap_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("hello world today friend", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("hello world today friend", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isEmpty();
     }
 
     @Test
-    @DisplayName("Should prefer higher priority when scores are equal")
-    void testPriorityBreaksTies() {
-        StampAnswer low = buildStampAnswer(1L, "What is Spring?", "spring", 1);
-        StampAnswer high = buildStampAnswer(2L, "What is Spring?", "spring", 10);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring", List.of(low, high), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+    @DisplayName("Should reject ambiguous match when two stamp answers score equally")
+    void testAmbiguousMatch_returnsEmpty() {
+        StampAnswer first = buildStampAnswer(1L, "What is Spring?", "spring");
+        StampAnswer second = buildStampAnswer(2L, "What is Spring?", "spring");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring", List.of(first, second), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should return clear winner when one stamp answer scores much higher")
+    void testClearWinner_returnsMatch() {
+        StampAnswer relevant = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot, framework");
+        StampAnswer irrelevant = buildStampAnswer(2L, "How to cook pasta?", "pasta, cooking");
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring Boot", List.of(relevant, irrelevant), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(2L);
+        assertThat(result.get().getId()).isEqualTo(1L);
     }
 
     @Test
     @DisplayName("Should return empty for empty stamp answer list")
     void testEmptyList_returnsEmpty() {
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring", List.of(), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring", List.of(), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isEmpty();
     }
 
     @Test
     @DisplayName("Should handle null keywords gracefully")
     void testNullKeywords() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", null, 5);
-        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring Boot", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", null);
+        Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring Boot", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD, AMBIGUITY_THRESHOLD);
         assertThat(result).isPresent();
     }
 }

--- a/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImplTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImplTest.java
@@ -35,6 +35,7 @@ class KeywordStampMatcherImplTest {
         config = new StampMatcherConfig();
         config.setMinInputLength(3);
         config.setKeywordThreshold(0.3);
+        config.setAmbiguityThreshold(0.1);
         matcher = new KeywordStampMatcherImpl(repository, config);
 
         testStampAnswer = StampAnswer.builder()
@@ -42,7 +43,6 @@ class KeywordStampMatcherImplTest {
                 .question("What is Spring Boot?")
                 .keywords("spring, boot, framework")
                 .answer("Spring Boot is a framework...")
-                .priority(5)
                 .isActive(true)
                 .build();
     }
@@ -50,17 +50,17 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should load cache on refresh")
     void testRefreshCache() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
 
         matcher.refreshCache();
 
-        verify(repository).findByIsActiveTrueOrderByPriorityDesc();
+        verify(repository).findByIsActiveTrueOrderByCreatedAtDesc();
     }
 
     @Test
     @DisplayName("Should find match with good keyword overlap")
     void testFindBestMatch_goodOverlap() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("What is Spring Boot");
@@ -72,7 +72,7 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should return empty for short input")
     void testFindBestMatch_shortInput() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("ab");
@@ -83,7 +83,7 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should return empty when cache is empty")
     void testFindBestMatch_emptyCache() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of());
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of());
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("What is Spring Boot");
@@ -94,7 +94,7 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should return empty for irrelevant input")
     void testFindBestMatch_noOverlap() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("hello world today");

--- a/bossbot/src/test/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImplTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImplTest.java
@@ -41,6 +41,7 @@ class OllamaStampMatcherImplTest {
         config.setSimilarityThreshold(0.7);
         config.setKeywordThreshold(0.3);
         config.setMinInputLength(3);
+        config.setAmbiguityThreshold(0.1);
         matcher = new OllamaStampMatcherImpl(repository, embeddingService, config);
 
         testStampAnswer = StampAnswer.builder()
@@ -48,7 +49,6 @@ class OllamaStampMatcherImplTest {
                 .question("What is Spring Boot?")
                 .keywords("spring, boot, framework")
                 .answer("Spring Boot is a framework...")
-                .priority(5)
                 .isActive(true)
                 .build();
     }
@@ -57,7 +57,7 @@ class OllamaStampMatcherImplTest {
     @DisplayName("Should find match when similarity is above threshold")
     void testFindBestMatch_highSimilarity() {
         double[] embedding = {0.1, 0.2, 0.3};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding));
         when(embeddingService.embed("What is Spring Boot")).thenReturn(embedding);
         matcher.refreshCache();
@@ -73,7 +73,7 @@ class OllamaStampMatcherImplTest {
     void testFindBestMatch_belowThreshold() {
         double[] docEmbedding = {1.0, 0.0};
         double[] queryEmbedding = {0.0, 1.0};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(docEmbedding));
         when(embeddingService.embed("random gibberish text")).thenReturn(queryEmbedding);
         matcher.refreshCache();
@@ -87,7 +87,7 @@ class OllamaStampMatcherImplTest {
     @DisplayName("Should fall back to keyword matching when Ollama is down at query time")
     void testFindBestMatch_ollamaDown_fallsBackToKeywords() {
         double[] embedding = {0.1, 0.2, 0.3};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding));
         matcher.refreshCache();
 
@@ -112,7 +112,7 @@ class OllamaStampMatcherImplTest {
     @DisplayName("Should recompute embeddings on cache refresh")
     void testRefreshCache_recomputesEmbeddings() {
         double[] embedding = {0.1, 0.2, 0.3};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding));
 
         matcher.refreshCache();
@@ -123,7 +123,7 @@ class OllamaStampMatcherImplTest {
     @Test
     @DisplayName("Should handle Ollama being down during cache refresh")
     void testRefreshCache_ollamaDown() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenThrow(new OllamaException("Connection refused"));
 
         matcher.refreshCache();
@@ -134,22 +134,21 @@ class OllamaStampMatcherImplTest {
     }
 
     @Test
-    @DisplayName("Should prefer higher priority stamp answer when similarities are equal")
-    void testFindBestMatch_respectsPriority() {
-        StampAnswer lowPriority = StampAnswer.builder()
-                .id(2L).question("What is Spring Boot?").keywords("spring").priority(1).isActive(true).build();
-        StampAnswer highPriority = StampAnswer.builder()
-                .id(3L).question("What is Spring Boot?").keywords("spring").priority(10).isActive(true).build();
+    @DisplayName("Should reject ambiguous match when similarities are equal")
+    void testFindBestMatch_ambiguousMatch() {
+        StampAnswer first = StampAnswer.builder()
+                .id(2L).question("What is Spring Boot?").keywords("spring").isActive(true).build();
+        StampAnswer second = StampAnswer.builder()
+                .id(3L).question("What is Spring Boot?").keywords("spring").isActive(true).build();
 
         double[] embedding = {0.5, 0.5, 0.5};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(highPriority, lowPriority));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(first, second));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding, embedding));
         when(embeddingService.embed("What is Spring Boot")).thenReturn(embedding);
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("What is Spring Boot");
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(3L);
+        assertThat(result).isEmpty();
     }
 }


### PR DESCRIPTION
Fixed a bug that came from merge conflict (browser merge conflict solver is not the best) 
+ stamp anwsers that overlap a lot , i.e kui kaugel on pood and kui kaugel on jõusaal , were triggered on the word "kaugel" due to ollama thinking they were close enough - added ambiguity check to make sure it has to be closer for either one to trigger. 