### PR TITLE
Fix tests

### DIFF
--- a/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
+++ b/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
@@ -165,6 +165,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         }
 
         return false;
+
+    }
     @PreDestroy
     void shutdown() {
         executor.shutdown();

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordMatchUtils.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordMatchUtils.java
@@ -36,7 +36,7 @@ final class KeywordMatchUtils {
             long unionSize = inputWords.size() + answerWords.size() - matchCount;
             double score = unionSize == 0 ? 0.0 : (double) matchCount / unionSize;
 
-            if (score > bestScore || (score == bestScore && bestMatch != null && sa.getPriority() > bestMatch.getPriority())) {
+            if (score > bestScore || (score == bestScore && bestMatch != null)) {
                 bestScore = score;
                 bestMatch = sa;
             }

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImpl.java
@@ -31,7 +31,7 @@ public class KeywordStampMatcherImpl implements StampMatcherService {
 
     @Override
     public void refreshCache() {
-        cache.set(List.copyOf(repository.findByIsActiveTrueOrderByPriorityDesc()));
+        cache.set(List.copyOf(repository.findByIsActiveTrueOrderByCreatedAtDesc()));
         log.info("Keyword stamp matcher cache refreshed ({} entries)", cache.get().size());
     }
 

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImpl.java
@@ -41,7 +41,7 @@ public class OllamaStampMatcherImpl implements StampMatcherService {
 
     @Override
     public void refreshCache() {
-        List<StampAnswer> active = repository.findByIsActiveTrueOrderByPriorityDesc();
+        List<StampAnswer> active = repository.findByIsActiveTrueOrderByCreatedAtDesc();
 
         if (active.isEmpty()) {
             cache.set(List.of());
@@ -114,8 +114,7 @@ public class OllamaStampMatcherImpl implements StampMatcherService {
                 if (entry.embedding() == null) continue;
                 double similarity = cosineSimilarity(inputEmbedding, entry.embedding());
                 if (similarity > bestSimilarity ||
-                        (similarity == bestSimilarity && bestMatch != null
-                                && entry.stampAnswer().getPriority() > bestMatch.getPriority())) {
+                        (similarity == bestSimilarity && bestMatch != null)) {
                     bestSimilarity = similarity;
                     bestMatch = entry.stampAnswer();
                 }

--- a/bossbot/src/test/java/com/example/bossbot/chat/handler/ChatWebSocketHandlerTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/chat/handler/ChatWebSocketHandlerTest.java
@@ -64,7 +64,7 @@ class ChatWebSocketHandlerTest {
         }
 
         // Then — all 3 should reach the chat service
-        verify(chatService, times(3)).processMessage(eq(1L), any(), any());
+        verify(chatService, times(3)).processMessage(eq(1L), anyString(), any(), any());
     }
 
     @Test
@@ -79,13 +79,13 @@ class ChatWebSocketHandlerTest {
         }
 
         // The 4th message goes through but sets cooldown
-        verify(chatService, times(4)).processMessage(eq(1L), any(), any());
+        verify(chatService, times(4)).processMessage(eq(1L), anyString(), any(), any());
 
         // 5th message should be rate limited
         handler.handleTextMessage(session, createMessage(1L, "Msg 5"));
 
         // Still only 4 calls to chatService
-        verify(chatService, times(4)).processMessage(eq(1L), any(), any());
+        verify(chatService, times(4)).processMessage(eq(1L), anyString(), any(), any());
 
         // Verify a RATE_LIMITED response was sent
         ArgumentCaptor<TextMessage> captor = ArgumentCaptor.forClass(TextMessage.class);
@@ -142,7 +142,7 @@ class ChatWebSocketHandlerTest {
         }
 
         // 4 before disconnect + 3 after reconnect = 7 total
-        verify(chatService, times(7)).processMessage(eq(1L), any(), any());
+        verify(chatService, times(7)).processMessage(eq(1L), anyString(), any(), any());
     }
 
     @Test

--- a/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordMatchUtilsTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordMatchUtilsTest.java
@@ -15,12 +15,11 @@ class KeywordMatchUtilsTest {
     private static final int MIN_INPUT_LENGTH = 3;
     private static final double KEYWORD_THRESHOLD = 0.3;
 
-    private StampAnswer buildStampAnswer(Long id, String question, String keywords, int priority) {
+    private StampAnswer buildStampAnswer(Long id, String question, String keywords) {
         return StampAnswer.builder()
                 .id(id)
                 .question(question)
                 .keywords(keywords)
-                .priority(priority)
                 .isActive(true)
                 .build();
     }
@@ -28,7 +27,7 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return empty for single letter input")
     void testSingleLetter_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("k", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isEmpty();
     }
@@ -36,7 +35,7 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return empty for two character input")
     void testTwoCharInput_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("hi", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isEmpty();
     }
@@ -44,7 +43,7 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return empty for null input")
     void testNullInput_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch(null, List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isEmpty();
     }
@@ -52,7 +51,7 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return empty for blank input")
     void testBlankInput_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("   ", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isEmpty();
     }
@@ -60,7 +59,7 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return match when input has good word overlap")
     void testGoodOverlap_returnsMatch() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot, framework", 5);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot, framework");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring Boot", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(1L);
@@ -69,7 +68,7 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return match when input matches keywords")
     void testMatchesKeywords() {
-        StampAnswer sa = buildStampAnswer(1L, "opening hours question", "hours, schedule, time", 5);
+        StampAnswer sa = buildStampAnswer(1L, "opening hours question", "hours, schedule, time");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("schedule time", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(1L);
@@ -78,19 +77,19 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should return empty when word overlap is too low")
     void testLowOverlap_returnsEmpty() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot", 5);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", "spring, boot");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("hello world today friend", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isEmpty();
     }
 
     @Test
-    @DisplayName("Should prefer higher priority when scores are equal")
-    void testPriorityBreaksTies() {
-        StampAnswer low = buildStampAnswer(1L, "What is Spring?", "spring", 1);
-        StampAnswer high = buildStampAnswer(2L, "What is Spring?", "spring", 10);
+    @DisplayName("hould return first match when scores are equal")
+    void testReturnsFirstWhenScoresEqual() {
+        StampAnswer low = buildStampAnswer(1L, "What is Spring?", "spring");
+        StampAnswer high = buildStampAnswer(2L, "What is Spring?", "spring");
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring", List.of(low, high), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(2L);
+        assertThat(result.get().getId()).isEqualTo(1L);
     }
 
     @Test
@@ -103,7 +102,7 @@ class KeywordMatchUtilsTest {
     @Test
     @DisplayName("Should handle null keywords gracefully")
     void testNullKeywords() {
-        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", null, 5);
+        StampAnswer sa = buildStampAnswer(1L, "What is Spring Boot?", null);
         Optional<StampAnswer> result = KeywordMatchUtils.findBestKeywordMatch("What is Spring Boot", List.of(sa), MIN_INPUT_LENGTH, KEYWORD_THRESHOLD);
         assertThat(result).isPresent();
     }

--- a/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImplTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/stampanswer/service/KeywordStampMatcherImplTest.java
@@ -42,7 +42,6 @@ class KeywordStampMatcherImplTest {
                 .question("What is Spring Boot?")
                 .keywords("spring, boot, framework")
                 .answer("Spring Boot is a framework...")
-                .priority(5)
                 .isActive(true)
                 .build();
     }
@@ -50,17 +49,17 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should load cache on refresh")
     void testRefreshCache() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
 
         matcher.refreshCache();
 
-        verify(repository).findByIsActiveTrueOrderByPriorityDesc();
+        verify(repository).findByIsActiveTrueOrderByCreatedAtDesc();
     }
 
     @Test
     @DisplayName("Should find match with good keyword overlap")
     void testFindBestMatch_goodOverlap() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("What is Spring Boot");
@@ -72,7 +71,7 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should return empty for short input")
     void testFindBestMatch_shortInput() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("ab");
@@ -83,7 +82,7 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should return empty when cache is empty")
     void testFindBestMatch_emptyCache() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of());
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of());
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("What is Spring Boot");
@@ -94,7 +93,7 @@ class KeywordStampMatcherImplTest {
     @Test
     @DisplayName("Should return empty for irrelevant input")
     void testFindBestMatch_noOverlap() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         matcher.refreshCache();
 
         Optional<StampAnswerResponse> result = matcher.findBestMatch("hello world today");

--- a/bossbot/src/test/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImplTest.java
+++ b/bossbot/src/test/java/com/example/bossbot/stampanswer/service/OllamaStampMatcherImplTest.java
@@ -48,7 +48,6 @@ class OllamaStampMatcherImplTest {
                 .question("What is Spring Boot?")
                 .keywords("spring, boot, framework")
                 .answer("Spring Boot is a framework...")
-                .priority(5)
                 .isActive(true)
                 .build();
     }
@@ -57,7 +56,7 @@ class OllamaStampMatcherImplTest {
     @DisplayName("Should find match when similarity is above threshold")
     void testFindBestMatch_highSimilarity() {
         double[] embedding = {0.1, 0.2, 0.3};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding));
         when(embeddingService.embed("What is Spring Boot")).thenReturn(embedding);
         matcher.refreshCache();
@@ -73,7 +72,7 @@ class OllamaStampMatcherImplTest {
     void testFindBestMatch_belowThreshold() {
         double[] docEmbedding = {1.0, 0.0};
         double[] queryEmbedding = {0.0, 1.0};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(docEmbedding));
         when(embeddingService.embed("random gibberish text")).thenReturn(queryEmbedding);
         matcher.refreshCache();
@@ -87,7 +86,7 @@ class OllamaStampMatcherImplTest {
     @DisplayName("Should fall back to keyword matching when Ollama is down at query time")
     void testFindBestMatch_ollamaDown_fallsBackToKeywords() {
         double[] embedding = {0.1, 0.2, 0.3};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding));
         matcher.refreshCache();
 
@@ -112,7 +111,7 @@ class OllamaStampMatcherImplTest {
     @DisplayName("Should recompute embeddings on cache refresh")
     void testRefreshCache_recomputesEmbeddings() {
         double[] embedding = {0.1, 0.2, 0.3};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding));
 
         matcher.refreshCache();
@@ -123,7 +122,7 @@ class OllamaStampMatcherImplTest {
     @Test
     @DisplayName("Should handle Ollama being down during cache refresh")
     void testRefreshCache_ollamaDown() {
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(testStampAnswer));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(testStampAnswer));
         when(embeddingService.embedBatch(any())).thenThrow(new OllamaException("Connection refused"));
 
         matcher.refreshCache();
@@ -134,15 +133,15 @@ class OllamaStampMatcherImplTest {
     }
 
     @Test
-    @DisplayName("Should prefer higher priority stamp answer when similarities are equal")
-    void testFindBestMatch_respectsPriority() {
-        StampAnswer lowPriority = StampAnswer.builder()
-                .id(2L).question("What is Spring Boot?").keywords("spring").priority(1).isActive(true).build();
-        StampAnswer highPriority = StampAnswer.builder()
-                .id(3L).question("What is Spring Boot?").keywords("spring").priority(10).isActive(true).build();
+    @DisplayName("Should return first stamp answer when similarities are equal")
+    void testFindBestMatch_returnsFirstWhenSimilaritiesAreEqual() {
+        StampAnswer first = StampAnswer.builder()
+                .id(2L).question("What is Spring Boot?").keywords("spring").isActive(true).build();
+        StampAnswer second = StampAnswer.builder()
+                .id(3L).question("What is Spring Boot?").keywords("spring").isActive(true).build();
 
         double[] embedding = {0.5, 0.5, 0.5};
-        when(repository.findByIsActiveTrueOrderByPriorityDesc()).thenReturn(List.of(highPriority, lowPriority));
+        when(repository.findByIsActiveTrueOrderByCreatedAtDesc()).thenReturn(List.of(first,second));
         when(embeddingService.embedBatch(any())).thenReturn(List.of(embedding, embedding));
         when(embeddingService.embed("What is Spring Boot")).thenReturn(embedding);
         matcher.refreshCache();
@@ -150,6 +149,6 @@ class OllamaStampMatcherImplTest {
         Optional<StampAnswerResponse> result = matcher.findBestMatch("What is Spring Boot");
 
         assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(3L);
+        assertThat(result.get().getId()).isEqualTo(2L);
     }
 }


### PR DESCRIPTION
- Updated tests after removing `priority` and `category` from StampAnswer
- Replaced deprecated repository method usages with `findByIsActiveTrueOrderByCreatedAtDesc`
- Removed priority-based assertions and adjusted logic to "first match wins"
- Updated ChatWebSocketHandlerTest to match new ChatService.processMessage signature (added cancelFlag)
- Fixed builder usages in tests