### PR TITLE
OAuth login flow, JWT signing and transactional auth service

### DIFF
--- a/bossbot/src/main/java/com/example/bossbot/auth/AuthController.java
+++ b/bossbot/src/main/java/com/example/bossbot/auth/AuthController.java
@@ -42,7 +42,7 @@ public class AuthController {
     @PostConstruct
     void validateConfig() {
         // Hardcoded due to security: validate on startup, to keep app from running if urls get compromised
-        List<String> allowedUrls = List.of("http://localhost:5173");
+        List<String> allowedUrls = List.of("http://localhost:5173", "http://bossbot.mooo.com");
         if(!allowedUrls.contains(frontendUrl)){
             throw new IllegalStateException("Untrusted frontend URL: " + frontendUrl);
         }
@@ -102,7 +102,7 @@ public class AuthController {
     private Cookie createOrClearJwtCookie(String token, Integer maxAgeSeconds){
         Cookie cookie = new Cookie("jwt", token);
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+        cookie.setSecure(frontendUrl.startsWith("https://"));
         cookie.setPath("/");
         cookie.setMaxAge(maxAgeSeconds);
 

--- a/bossbot/src/main/java/com/example/bossbot/auth/AuthService.java
+++ b/bossbot/src/main/java/com/example/bossbot/auth/AuthService.java
@@ -10,6 +10,7 @@ import com.example.bossbot.user.UserMapper;
 import com.example.bossbot.user.UserRepository;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
@@ -41,6 +42,7 @@ public class AuthService {
         this.roleRepository = roleRepository;
     }
 
+    @Transactional
     public AuthResult processOAuthLogin(OAuth2AuthenticationToken auth) {
         String email = requireEmail(auth);
         String name = auth.getPrincipal().getAttribute("name");

--- a/bossbot/src/main/java/com/example/bossbot/security/JwtService.java
+++ b/bossbot/src/main/java/com/example/bossbot/security/JwtService.java
@@ -48,7 +48,7 @@ public class JwtService {
                 .subject(subject)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + expirationMs))
-                .signWith(key)
+                .signWith(key, io.jsonwebtoken.SignatureAlgorithm.HS256)
                 .compact();
     }
 }

--- a/bossbot/src/main/java/com/example/bossbot/security/SecurityConfig.java
+++ b/bossbot/src/main/java/com/example/bossbot/security/SecurityConfig.java
@@ -39,6 +39,9 @@ import java.util.List;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+import com.example.bossbot.auth.AuthService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+
 /**
  * Configuration class for Spring Security.
  * Defines authentication and authorization rules, configures JWT-based stateless sessions,
@@ -60,6 +63,14 @@ public class SecurityConfig {
     private final ClientRegistrationRepository clientRegistrationRepository;
     @Value("${app.security.permit-all:false}") // by default false
     private boolean permitAll;
+
+    // Frontend base URL used for redirect after successful OAuth login
+    @Value("${app.frontend.url}")
+    private String frontendUrl;
+
+    // JWT cookie lifetime (used when issuing auth cookie after login)
+    @Value("${jwt.expiration.milliseconds}")
+    private int jwtCookieMaxAgeMilliSeconds;
 
     @Bean
     public JwtDecoder jwtDecoder(JwtService jwtService) {
@@ -83,7 +94,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
                                                    CorsConfigurationSource corsConfigurationSource,
                                                    UserRepository userRepository,
-                                                   JwtDecoder jwtDecoder) throws Exception {
+                                                   JwtDecoder jwtDecoder,
+                                                   AuthService authService) throws Exception {
 
         DefaultOAuth2AuthorizationRequestResolver defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
                 clientRegistrationRepository, "/oauth2/authorization");
@@ -140,8 +152,28 @@ public class SecurityConfig {
                                 request -> request.getRequestURI().startsWith("/api/")
                         )
                 )
+                // Custom OAuth2 success flow:
+                // After successful Google authentication:
+                // Convert OAuth user → application user and issue JWT
+                // Set JWT as HTTP-only cookie (used by backend for auth)
+                // Redirect to frontend ("/"), so app loads with authenticated session
+                // Needed because defaultSuccessUrl does not allow setting JWT cookie
                 .oauth2Login(oauth2 -> oauth2
-                        .defaultSuccessUrl("/auth/login/success", true)
+                        .successHandler((request, response, authentication) -> {
+                            OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+
+                            var result = authService.processOAuthLogin(oauthToken);
+                            int jwtCookieMaxAgeSeconds = jwtCookieMaxAgeMilliSeconds / 1000;
+
+                            Cookie cookie = new Cookie("jwt", result.dto().token());
+                            cookie.setHttpOnly(true);
+                            cookie.setSecure(frontendUrl.startsWith("https://"));
+                            cookie.setPath("/");
+                            cookie.setMaxAge(jwtCookieMaxAgeSeconds);
+
+                            response.addCookie(cookie);
+                            response.sendRedirect(frontendUrl + "/");
+                        })
                         .authorizationEndpoint(auth -> auth.authorizationRequestResolver(customResolver)))
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.decoder(jwtDecoder)

--- a/bossbot/src/main/resources/application-production.properties
+++ b/bossbot/src/main/resources/application-production.properties
@@ -54,7 +54,8 @@ app.frontend.url=${APP_FRONTEND_URL}
 # Actuator and Metrics - Secure Configuration for Production
 management.server.port=8080
 management.endpoints.web.exposure.include=health,prometheus,info
-management.endpoint.health.show-details=never  # Hide internal details
+# Hide internal details
+management.endpoint.health.show-details=NEVER
 management.endpoint.env.show-values=NEVER
 management.endpoint.configprops.show-values=NEVER
 management.endpoint.prometheus.enabled=true


### PR DESCRIPTION
1. Custom OAuth2 success handler (SecurityConfig)

Replaced defaultSuccessUrl("/auth/login/success") with a custom successHandler.

Why:
The default Spring Security flow does not allow setting a JWT cookie during OAuth login.
We need to:
- convert OAuth user → application user
- generate JWT
- store JWT in HTTP-only cookie
- redirect to frontend

This ensures the frontend immediately has an authenticated session after login.

---

2. @Transactional added to AuthService.processOAuthLogin

Why:
Production logs showed:
LazyInitializationException: Could not initialize proxy (Role)

This happens because:
- user.role is LAZY loaded
- mapping happens after Hibernate session is closed

@Transactional ensures the session stays open during mapping and prevents this error.

---

3. JWT signing algorithm explicitly set (HS256)

Change:
.signWith(key) → .signWith(key, SignatureAlgorithm.HS256)

Why:
Spring Security JWT decoder rejected tokens with error:
"Another algorithm expected"

Root cause:
- encoder defaulted to a different algorithm (e.g. HS512)
- decoder expected HS256

Explicitly setting HS256 ensures compatibility between encoder and decoder.

---

4. Cookie secure flag made environment-aware

Change:
cookie.setSecure(true) → cookie.setSecure(frontendUrl.startsWith("https://"))

Why:
- In production (HTTPS) → cookie must be secure
- In local dev (HTTP) → secure cookies are ignored by browser

This fix allows authentication to work both locally and in production.

---

5. Allowed frontend URLs updated

Added:
http://bossbot.mooo.com

Why:
Production frontend URL must be explicitly allowed to pass validation.

---

6. application-production.properties fix

Moved inline comment to separate line.

Why:
Inline comments can break property parsing in some cases and are not safe for production configs.

---

Result

- OAuth login works end-to-end (Google → backend → frontend)
- JWT is correctly issued and accepted
- No LazyInitializationException
- Works both locally (HTTP) and in production (HTTPS)

Tested locally with Docker and OAuth login flow.