### PR TITLE
67 - BE Authorization implementation. Secure authorization and chat ownership rules

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -37,3 +37,6 @@ GF_SECURITY_ADMIN_PASSWORD=change-this-password
 GF_USERS_ALLOW_SIGN_UP=false
 GF_SERVER_ROOT_URL=http://localhost:3000
 GF_AUTH_ANONYMOUS_ENABLED=false
+
+# Add e-mails for admin users (add admin e-mail(s), comma-separated)
+ADMIN_BOOTSTRAP_EMAILS=adminemail@gmail.com,admin2email@gmail.com

--- a/bossbot/src/main/java/com/example/bossbot/auth/AuthController.java
+++ b/bossbot/src/main/java/com/example/bossbot/auth/AuthController.java
@@ -32,7 +32,7 @@ public class AuthController {
     private String frontendUrl;
     @Value("${jwt.expiration.milliseconds}")
     private int jwtCookieMaxAgeMilliSeconds;
-    private static final String POST_LOGIN_REDIRECT_PATH = "/";
+    private static final String POST_LOGIN_REDIRECT_USER_PATH = "/";
     private static final String LOGIN_ERROR_REDIRECT_PATH = "/login?error=auth_failure";
 
     public AuthController(AuthService authService) {
@@ -58,10 +58,13 @@ public class AuthController {
             int jwtCookieMaxAgeSeconds = jwtCookieMaxAgeMilliSeconds / 1000;
             Cookie cookie = createOrClearJwtCookie(result.dto().token(), jwtCookieMaxAgeSeconds);
             response.addCookie(cookie);
-            response.sendRedirect(frontendUrl + POST_LOGIN_REDIRECT_PATH);
+
+            response.sendRedirect(frontendUrl + POST_LOGIN_REDIRECT_USER_PATH);
+
         } catch (Exception e) {
             // TODO:: create FE error page
             log.error("OAuth login failed: ", e);
+
             response.sendRedirect(frontendUrl + LOGIN_ERROR_REDIRECT_PATH);
         }
     }

--- a/bossbot/src/main/java/com/example/bossbot/auth/AuthController.java
+++ b/bossbot/src/main/java/com/example/bossbot/auth/AuthController.java
@@ -74,6 +74,11 @@ public class AuthController {
         HttpSession session = request.getSession(false);
         if (session != null) {
             session.invalidate();
+            Cookie sessionCookie = new Cookie("JSESSIONID", "");
+            sessionCookie.setPath("/");
+            sessionCookie.setHttpOnly(true);
+            sessionCookie.setMaxAge(0);
+            response.addCookie(sessionCookie);
         }
 
         SecurityContextHolder.clearContext();

--- a/bossbot/src/main/java/com/example/bossbot/auth/AuthService.java
+++ b/bossbot/src/main/java/com/example/bossbot/auth/AuthService.java
@@ -8,9 +8,14 @@ import com.example.bossbot.user.User;
 import com.example.bossbot.user.UserAuthDto;
 import com.example.bossbot.user.UserMapper;
 import com.example.bossbot.user.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import java.time.Instant;
 
@@ -27,19 +32,20 @@ import static com.example.bossbot.security.OAuth2AuthValidator.requireEmail;
 @Service
 public class AuthService {
     private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
     private final JwtService jwtService;
     private final UserMapper userMapper;
-    private final RoleRepository roleRepository;
+    @Value("${app.auth.admin-bootstrap-emails:}")
+    private String adminBootstrapEmails;
 
     public record AuthResult(UserAuthDto dto) {
     }
 
-    public AuthService(UserRepository userRepository, JwtService jwtService, UserMapper userMapper,
-                       RoleRepository roleRepository) {
+    public AuthService(UserRepository userRepository, RoleRepository roleRepository, JwtService jwtService, UserMapper userMapper) {
         this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
         this.jwtService = jwtService;
         this.userMapper = userMapper;
-        this.roleRepository = roleRepository;
     }
 
     @Transactional
@@ -49,15 +55,21 @@ public class AuthService {
 
         // Check if user exists or create a new one
         User dbUser = userRepository.findByEmail(email)
-                .orElse(User.builder()
+                .orElse(User
+                        .builder()
                         .email(email)
                         .name(name)
-                        .build());
+                        .build()
+                );
 
-        if (dbUser.getRole() == null) {
-            Role defaultRole = roleRepository.findByRoleName(RoleName.USER)
-                    .orElseThrow(() -> new IllegalArgumentException("Default role USER not found"));
-            dbUser.setRole(defaultRole);
+        String normalizedEmail = email.trim().toLowerCase(Locale.ROOT);
+        boolean isBootstrapAdmin = adminEmailSet().contains(normalizedEmail);
+
+        if (dbUser.getRole() == null || dbUser.getRole().getRoleName() == null) {
+            RoleName targetRole = isBootstrapAdmin ? RoleName.ADMIN : RoleName.USER;
+            Role role = roleRepository.findByRoleName(targetRole)
+                    .orElseGet(() -> roleRepository.save(Role.builder().roleName(targetRole).build()));
+            dbUser.setRole(role);
         }
 
         // Update name in case it changed
@@ -68,8 +80,21 @@ public class AuthService {
 
         // Issue JWT
         String token = jwtService.generateToken(dbUser.getEmail());
-
         return new AuthResult(userMapper.toDto(dbUser, token));
     }
+
+
+     // AuthService.java (add helper)
+     private Set<String> adminEmailSet() {
+         if (adminBootstrapEmails == null || adminBootstrapEmails.isBlank()) {
+             return Set.of();
+         }
+
+         return Arrays.stream(adminBootstrapEmails.split(","))
+                 .map(String::trim)
+                 .map(s -> s.toLowerCase(Locale.ROOT))
+                 .filter(s -> !s.isBlank())
+                 .collect(Collectors.toSet());
+     }
 }
 

--- a/bossbot/src/main/java/com/example/bossbot/auth/DevAuthController.java
+++ b/bossbot/src/main/java/com/example/bossbot/auth/DevAuthController.java
@@ -1,0 +1,55 @@
+package com.example.bossbot.auth;
+
+import com.example.bossbot.security.JwtService;
+import com.example.bossbot.user.User;
+import com.example.bossbot.user.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Development-only authentication controller used to simulate user login in a local environment.
+ * Provides an endpoint to generate and set authentication tokens as cookies for specific users.
+ *
+ * This controller is active only in the "local" Spring profile.
+ *
+ * Dependencies:
+ * - {@link UserRepository}: Provides access to user data from the database.
+ * - {@link JwtService}: Responsible for generating JWT tokens.
+ *
+ * Endpoints:
+ * - POST "/auth/dev/login-as/{userId}":
+ *   Allows an administrator or developer to emulate a user login by their user ID.
+ *   Generates a JWT token for the specified user and sets it as an HTTP-only cookie
+ *   in the response. The token is valid for 24 hours and intended for local testing purposes.
+ */
+
+@Profile("local")
+@RestController
+@RequestMapping("/auth/dev")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    @PostMapping("/login-as/{userId}")
+    public ResponseEntity<Void> loginAs(@PathVariable Long userId, HttpServletResponse response) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+        String token = jwtService.generateToken(user.getEmail());
+
+        Cookie cookie = new Cookie("jwt", token);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false); // local http
+        cookie.setPath("/");
+        cookie.setMaxAge(24 * 60 * 60);
+        response.addCookie(cookie);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/bossbot/src/main/java/com/example/bossbot/auth/LocalLoginController.java
+++ b/bossbot/src/main/java/com/example/bossbot/auth/LocalLoginController.java
@@ -1,0 +1,29 @@
+package com.example.bossbot.auth;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+/**
+ * Controller for handling authentication-related requests in the local profile.
+ *
+ * This controller is active only when the application is running in the "local" profile,
+ * as specified by the `@Profile("local")` annotation. It contains a single endpoint
+ * for redirecting users to the frontend application when accessing the local login route.
+ *
+ * Endpoint:
+ * - GET /auth/login: Redirects the user to the local frontend URL at "http://localhost:5173".
+ */
+@Profile("local")
+@RestController
+public class LocalLoginController {
+    @GetMapping("/auth/login")
+    public void login(HttpServletResponse response) throws IOException {
+        // Redirect with local profile
+        response.sendRedirect("http://localhost:5173");
+    }
+}

--- a/bossbot/src/main/java/com/example/bossbot/bannedword/controller/BannedWordController.java
+++ b/bossbot/src/main/java/com/example/bossbot/bannedword/controller/BannedWordController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,6 +26,7 @@ public class BannedWordController {
 
     private final BannedWordService bannedWordService;
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create a new banned word")
     @ApiResponse(responseCode = "201", description = "Banned word created successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
@@ -36,6 +38,7 @@ public class BannedWordController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @Operation(summary = "Get banned word by ID")
     @ApiResponse(responseCode = "200", description = "Banned word found")
     @ApiResponse(responseCode = "404", description = "Banned word not found")
@@ -47,6 +50,7 @@ public class BannedWordController {
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get all banned words")
     @ApiResponse(responseCode = "200", description = "Banned words returned")
     @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -60,6 +64,7 @@ public class BannedWordController {
         return ResponseEntity.ok(responses);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get banned words by category")
     @ApiResponse(responseCode = "200", description = "Banned words returned")
     @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -70,6 +75,7 @@ public class BannedWordController {
         return ResponseEntity.ok(responses);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update a banned word")
     @ApiResponse(responseCode = "200", description = "Banned word updated successfully")
     @ApiResponse(responseCode = "404", description = "Banned word not found")
@@ -84,6 +90,7 @@ public class BannedWordController {
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete (deactivate) a banned word")
     @ApiResponse(responseCode = "204", description = "Banned word deleted successfully")
     @ApiResponse(responseCode = "404", description = "Banned word not found")

--- a/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
+++ b/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
@@ -26,6 +26,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.Authentication;
+
 @Component
 @Slf4j
 public class ChatWebSocketHandler extends TextWebSocketHandler {
@@ -102,14 +106,39 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             AtomicBoolean cancelFlag = new AtomicBoolean(false);
             cancelFlags.put(session.getId(), cancelFlag);
 
+            // Resolve the authenticated user from the WebSocket session before entering the worker thread
+            Authentication authentication = null;
+
+            if (session.getPrincipal() instanceof Authentication auth) {
+                authentication = auth;
+            } else {
+                authentication = SecurityContextHolder.getContext().getAuthentication();
+            }
+
+            // Reject unauthenticated WebSocket messages and clean up per-session state
+            if (authentication == null || !authentication.isAuthenticated()) {
+                log.warn("WebSocket message rejected because session is not authenticated: {}", session.getId());
+                sendResponse(safeSession, ChatWebSocketResponse.error("Not authenticated"));
+                cancelFlags.remove(session.getId());
+                processing.remove(session.getId());
+                return;
+            }
+
+            // Make the authenticated user available to services that read SecurityContextHolder
+            SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+            securityContext.setAuthentication(authentication);
+
             executor.execute(() -> {
                 try {
+                    SecurityContextHolder.setContext(securityContext);
+
                     chatService.processMessage(message.getConversationId(), message.getContent(),
                             response -> sendResponse(safeSession, response), cancelFlag);
                 } catch (Exception e) {
                     log.error("Error processing message: {}", e.getMessage(), e);
                     sendResponse(safeSession, ChatWebSocketResponse.error("Failed to process message"));
                 } finally {
+                    SecurityContextHolder.clearContext();
                     cancelFlags.remove(session.getId());
                     processing.remove(session.getId());
                 }

--- a/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
+++ b/bossbot/src/main/java/com/example/bossbot/chat/handler/ChatWebSocketHandler.java
@@ -107,20 +107,13 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             cancelFlags.put(session.getId(), cancelFlag);
 
             // Resolve the authenticated user from the WebSocket session before entering the worker thread
-            Authentication authentication = null;
-
-            if (session.getPrincipal() instanceof Authentication auth) {
-                authentication = auth;
-            } else {
-                authentication = SecurityContextHolder.getContext().getAuthentication();
-            }
+            Authentication authentication = resolveAuthentication(session);
 
             // Reject unauthenticated WebSocket messages and clean up per-session state
-            if (authentication == null || !authentication.isAuthenticated()) {
+            if (isUnauthenticated(authentication)) {
                 log.warn("WebSocket message rejected because session is not authenticated: {}", session.getId());
                 sendResponse(safeSession, ChatWebSocketResponse.error("Not authenticated"));
-                cancelFlags.remove(session.getId());
-                processing.remove(session.getId());
+                clearProcessingState(session.getId());
                 return;
             }
 
@@ -139,8 +132,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                     sendResponse(safeSession, ChatWebSocketResponse.error("Failed to process message"));
                 } finally {
                     SecurityContextHolder.clearContext();
-                    cancelFlags.remove(session.getId());
-                    processing.remove(session.getId());
+                    clearProcessingState(session.getId());
                 }
             });
 
@@ -148,6 +140,23 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             log.error("Error handling WebSocket message: {}", e.getMessage(), e);
             sendResponse(safeSession, ChatWebSocketResponse.error("Failed to process message"));
         }
+    }
+
+    private Authentication resolveAuthentication(WebSocketSession session) {
+        if (session.getPrincipal() instanceof Authentication auth) {
+            return auth;
+        }
+
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+
+    private boolean isUnauthenticated(Authentication authentication) {
+        return authentication == null || !authentication.isAuthenticated();
+    }
+
+    private void clearProcessingState(String sessionId) {
+        cancelFlags.remove(sessionId);
+        processing.remove(sessionId);
     }
 
     @Override

--- a/bossbot/src/main/java/com/example/bossbot/conversation/controller/ConversationController.java
+++ b/bossbot/src/main/java/com/example/bossbot/conversation/controller/ConversationController.java
@@ -35,8 +35,7 @@ public class ConversationController {
     @ApiResponse(responseCode = "201", description = "Conversation created successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
     @PostMapping
-    public ResponseEntity<@NonNull ConversationResponse> create(@Valid @RequestBody CreateConversationRequest request,
-        @RequestParam Long userId) {
+    public ResponseEntity<@NonNull ConversationResponse> create(@Valid @RequestBody CreateConversationRequest request) {
         log.info("REST request to create conversation with title: {}", request.getTitle());
         ConversationResponse response = conversationService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -62,12 +61,11 @@ public class ConversationController {
      */
     @Operation(summary = "Get all conversations for user")
     @ApiResponse(responseCode = "200", description = "Conversations returned")
-    @ApiResponse(responseCode = "400", description = "userId query parameter is required") // TODO: Temporary 400 status code as later from auth
+//    @ApiResponse(responseCode = "400", description = "userId query parameter is required") // TODO: Temporary 400 status code as later from auth
     @GetMapping
-    public ResponseEntity<@NonNull List<ConversationResponse>> getAll(
-            @RequestParam Long userId) { // TODO: Later from auth
+    public ResponseEntity<@NonNull List<ConversationResponse>> getAll() {
         log.info("REST request to get conversations");
-        List<ConversationResponse> responses = conversationService.getAll(userId); // TODO: Later from auth
+        List<ConversationResponse> responses = conversationService.getAll();
         return ResponseEntity.ok(responses);
     }
 
@@ -77,12 +75,11 @@ public class ConversationController {
      */
     @Operation(summary = "Get all conversations for user")
     @ApiResponse(responseCode = "200", description = "Conversations returned")
-    @ApiResponse(responseCode = "400", description = "userId query parameter is required") // TODO: Temporary 400 status code as later from auth
+//    @ApiResponse(responseCode = "400", description = "userId query parameter is required") // TODO: Temporary 400 status code as later from auth
     @GetMapping("/active")
-    public ResponseEntity<@NonNull List<ConversationResponse>> getAllActive(
-            @RequestParam Long userId) { // TODO: Later from auth
+    public ResponseEntity<@NonNull List<ConversationResponse>> getAllActive() {
         log.info("REST request to get active conversations");
-        List<ConversationResponse> responses = conversationService.getAllActive(userId); // TODO: Later from auth
+        List<ConversationResponse> responses = conversationService.getAllActive();
         return ResponseEntity.ok(responses);
     }
 

--- a/bossbot/src/main/java/com/example/bossbot/conversation/controller/ConversationController.java
+++ b/bossbot/src/main/java/com/example/bossbot/conversation/controller/ConversationController.java
@@ -61,7 +61,6 @@ public class ConversationController {
      */
     @Operation(summary = "Get all conversations for user")
     @ApiResponse(responseCode = "200", description = "Conversations returned")
-//    @ApiResponse(responseCode = "400", description = "userId query parameter is required") // TODO: Temporary 400 status code as later from auth
     @GetMapping
     public ResponseEntity<@NonNull List<ConversationResponse>> getAll() {
         log.info("REST request to get conversations");
@@ -75,7 +74,6 @@ public class ConversationController {
      */
     @Operation(summary = "Get all conversations for user")
     @ApiResponse(responseCode = "200", description = "Conversations returned")
-//    @ApiResponse(responseCode = "400", description = "userId query parameter is required") // TODO: Temporary 400 status code as later from auth
     @GetMapping("/active")
     public ResponseEntity<@NonNull List<ConversationResponse>> getAllActive() {
         log.info("REST request to get active conversations");

--- a/bossbot/src/main/java/com/example/bossbot/conversation/repository/ConversationRepository.java
+++ b/bossbot/src/main/java/com/example/bossbot/conversation/repository/ConversationRepository.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface ConversationRepository extends JpaRepository<@NonNull Conversation, @NonNull Long> {
@@ -13,5 +14,7 @@ public interface ConversationRepository extends JpaRepository<@NonNull Conversat
     List<Conversation> findByUserIdOrderByUpdatedAtAsc(Long id);
 
     List<Conversation> findByUserIdAndActiveTrueOrderByUpdatedAtAsc(Long id);
+
+    Optional<Conversation> findByIdAndUserId(Long conversationId, Long userId);
 
 }

--- a/bossbot/src/main/java/com/example/bossbot/conversation/service/ConversationService.java
+++ b/bossbot/src/main/java/com/example/bossbot/conversation/service/ConversationService.java
@@ -3,8 +3,10 @@ package com.example.bossbot.conversation.service;
 import com.example.bossbot.conversation.dto.ConversationResponse;
 import com.example.bossbot.conversation.dto.CreateConversationRequest;
 import com.example.bossbot.conversation.dto.UpdateConversationRequest;
+import com.example.bossbot.conversation.entity.Conversation;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ConversationService {
 
@@ -21,12 +23,12 @@ public interface ConversationService {
     /**
      * Get all user conversations, ordered latest updated first.
      */
-    List<ConversationResponse> getAll(Long userId); // TODO: from auth
+    List<ConversationResponse> getAll(); // from auth
 
     /**
      * Get all active user conversations, ordered latest updated first.
      */
-    List<ConversationResponse> getAllActive(Long userId); // TODO: from auth
+    List<ConversationResponse> getAllActive(); // from auth
 
     /**
      * Update a conversation
@@ -37,4 +39,5 @@ public interface ConversationService {
      * Soft delete a conversation
      */
     void delete(Long id);
+
 }

--- a/bossbot/src/main/java/com/example/bossbot/conversation/service/ConversationServiceImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/conversation/service/ConversationServiceImpl.java
@@ -7,7 +7,6 @@ import com.example.bossbot.conversation.dto.UpdateConversationRequest;
 import com.example.bossbot.conversation.entity.Conversation;
 import com.example.bossbot.conversation.repository.ConversationRepository;
 import com.example.bossbot.user.User;
-import com.example.bossbot.user.UserRepository;
 import com.example.bossbot.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,17 +23,12 @@ public class ConversationServiceImpl implements ConversationService {
     private static final String CONVERSATION_NOT_FOUND = "Conversation not found with ID: ";
 
     private final ConversationRepository repository;
-//    private final UserRepository userRepository;
 
     @Override
     @Transactional
     public ConversationResponse create(CreateConversationRequest request) {
         User currentUser = SecurityUtils.getCurrentUser();
         log.info("Creating new conversation: {}", request.getTitle());
-
-        // TODO: Replace with authenticated user ID from Spring Security context
-//        Long currentUserId = 1L; // placeholder until Spring Security
-//        User currentUser = userRepository.findById(currentUserId).orElseThrow();
 
         Conversation entity = Conversation.builder()
                 .title(request.getTitle())
@@ -90,8 +84,6 @@ public class ConversationServiceImpl implements ConversationService {
 
         Conversation entity = repository.findByIdAndUserId(id, currentUserId)
                 .orElseThrow(() -> new IllegalArgumentException(CONVERSATION_NOT_FOUND + id));
-
-//        Long currentUserId = 1L; // placeholder until Spring Security
 
         if (request.getTitle() != null) {
             entity.setTitle(request.getTitle());

--- a/bossbot/src/main/java/com/example/bossbot/conversation/service/ConversationServiceImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/conversation/service/ConversationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.bossbot.conversation.service;
 
+import com.example.bossbot.common.ResourceNotFoundException;
 import com.example.bossbot.conversation.dto.ConversationResponse;
 import com.example.bossbot.conversation.dto.CreateConversationRequest;
 import com.example.bossbot.conversation.dto.UpdateConversationRequest;
@@ -7,6 +8,7 @@ import com.example.bossbot.conversation.entity.Conversation;
 import com.example.bossbot.conversation.repository.ConversationRepository;
 import com.example.bossbot.user.User;
 import com.example.bossbot.user.UserRepository;
+import com.example.bossbot.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,21 +24,22 @@ public class ConversationServiceImpl implements ConversationService {
     private static final String CONVERSATION_NOT_FOUND = "Conversation not found with ID: ";
 
     private final ConversationRepository repository;
-    private final UserRepository userRepository;
+//    private final UserRepository userRepository;
 
     @Override
     @Transactional
     public ConversationResponse create(CreateConversationRequest request) {
+        User currentUser = SecurityUtils.getCurrentUser();
         log.info("Creating new conversation: {}", request.getTitle());
 
         // TODO: Replace with authenticated user ID from Spring Security context
-        Long currentUserId = 1L; // placeholder until Spring Security
-        User currentUser = userRepository.findById(currentUserId).orElseThrow();
+//        Long currentUserId = 1L; // placeholder until Spring Security
+//        User currentUser = userRepository.findById(currentUserId).orElseThrow();
 
         Conversation entity = Conversation.builder()
                 .title(request.getTitle())
                 .active(true)
-                .user(currentUser) //TODO: Replace with authenticated user from Spring Security context
+                .user(currentUser)
                 .build();
 
         Conversation saved = repository.save(entity);
@@ -48,9 +51,10 @@ public class ConversationServiceImpl implements ConversationService {
     @Override
     @Transactional(readOnly = true)
     public ConversationResponse getById(Long id) {
+        Long currentUserId = SecurityUtils.getCurrentUser().getId();
         log.info("Fetching conversation with ID: {}", id);
 
-        Conversation entity = repository.findById(id)
+        Conversation entity = repository.findByIdAndUserId(id, currentUserId)
                 .orElseThrow(() -> new IllegalArgumentException(CONVERSATION_NOT_FOUND + id));
 
         return ConversationResponse.fromEntity(entity);
@@ -58,20 +62,22 @@ public class ConversationServiceImpl implements ConversationService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ConversationResponse> getAll(Long userId) { // TODO: Later from auth
-        log.info("Fetching all conversations for user with ID: {}", userId);
+    public List<ConversationResponse> getAll() {
+        Long currentUserId = SecurityUtils.getCurrentUser().getId();
+        log.info("Fetching all conversations for user with ID: {}", currentUserId);
 
-        return repository.findByUserIdOrderByUpdatedAtAsc(userId).stream()
+        return repository.findByUserIdOrderByUpdatedAtAsc(currentUserId).stream()
                 .map(ConversationResponse::fromEntity)
                 .toList();
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<ConversationResponse> getAllActive(Long userId) {
+    public List<ConversationResponse> getAllActive() {
+        Long currentUserId = SecurityUtils.getCurrentUser().getId();
         log.info("Fetching all active conversations");
 
-        return repository.findByUserIdAndActiveTrueOrderByUpdatedAtAsc(userId).stream()
+        return repository.findByUserIdAndActiveTrueOrderByUpdatedAtAsc(currentUserId).stream()
                 .map(ConversationResponse::fromEntity)
                 .toList();
     }
@@ -79,12 +85,13 @@ public class ConversationServiceImpl implements ConversationService {
     @Override
     @Transactional
     public ConversationResponse update(Long id, UpdateConversationRequest request) {
+        Long currentUserId = SecurityUtils.getCurrentUser().getId();
         log.info("Updating conversation with ID: {}", id);
 
-        Conversation entity = repository.findById(id)
+        Conversation entity = repository.findByIdAndUserId(id, currentUserId)
                 .orElseThrow(() -> new IllegalArgumentException(CONVERSATION_NOT_FOUND + id));
 
-        Long currentUserId = 1L; // placeholder until Spring Security
+//        Long currentUserId = 1L; // placeholder until Spring Security
 
         if (request.getTitle() != null) {
             entity.setTitle(request.getTitle());
@@ -102,10 +109,11 @@ public class ConversationServiceImpl implements ConversationService {
     @Override
     @Transactional
     public void delete(Long id) {
+        Long currentUserId = SecurityUtils.getCurrentUser().getId();
         log.info("Soft deleting conversation with ID: {}", id);
 
-        Conversation entity = repository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException(CONVERSATION_NOT_FOUND + id));
+        Conversation entity = repository.findByIdAndUserId(id, currentUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Conversation not found with ID: " + id));
 
         entity.setActive(false);
         repository.save(entity);

--- a/bossbot/src/main/java/com/example/bossbot/message/service/MessageServiceImpl.java
+++ b/bossbot/src/main/java/com/example/bossbot/message/service/MessageServiceImpl.java
@@ -1,10 +1,13 @@
 package com.example.bossbot.message.service;
 
 import com.example.bossbot.common.ResourceNotFoundException;
+import com.example.bossbot.conversation.repository.ConversationRepository;
 import com.example.bossbot.message.dto.CreateMessageRequest;
 import com.example.bossbot.message.dto.MessageResponse;
 import com.example.bossbot.message.entity.Message;
 import com.example.bossbot.message.repository.MessageRepository;
+import com.example.bossbot.user.User;
+import com.example.bossbot.util.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,17 +20,22 @@ import java.util.List;
 @Slf4j
 public class MessageServiceImpl implements MessageService {
 
-    private static final String MESSAGE_NOT_FOUND = "Message not found with ID: ";
+    // Use generic "Message not found" for security reasons (even when conversation not found)
+    private static final String MESSAGE_NOT_FOUND = "Message not found";
 
     private final MessageRepository repository;
+    private final ConversationRepository conversationRepository;
 
     @Override
     @Transactional
     public MessageResponse create(CreateMessageRequest request) {
+        User currentUser = SecurityUtils.getCurrentUser();
+
+        requireConversationOwnedByCurrentUser(request.getConversationId(), currentUser.getId());
         log.info("Creating new message in conversation: {}", request.getConversationId());
 
-        // TODO: Replace with authenticated user ID from Spring Security context
-        Long currentUserId = 1L;
+        // Authenticated user ID from Spring Security context
+        Long currentUserId = currentUser.getId();
 
         Message entity = Message.builder()
                 .conversationId(request.getConversationId())
@@ -46,10 +54,12 @@ public class MessageServiceImpl implements MessageService {
     @Override
     @Transactional(readOnly = true)
     public MessageResponse getById(Long id) {
+        User currentUser = SecurityUtils.getCurrentUser();
         log.info("Fetching message with ID: {}", id);
 
         Message entity = repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(MESSAGE_NOT_FOUND + id));
+                .orElseThrow(() -> new ResourceNotFoundException(MESSAGE_NOT_FOUND));
+        requireConversationOwnedByCurrentUser(entity.getConversationId(), currentUser.getId());
 
         return MessageResponse.fromEntity(entity);
     }
@@ -57,6 +67,10 @@ public class MessageServiceImpl implements MessageService {
     @Override
     @Transactional(readOnly = true)
     public List<MessageResponse> getAll(Long conversationId) {
+        User currentUser = SecurityUtils.getCurrentUser();
+
+        requireConversationOwnedByCurrentUser(conversationId, currentUser.getId());
+
         log.info("Fetching messages for conversation ID: {}", conversationId);
         return repository.findByConversationIdAndIsActiveTrueOrderByCreatedAtAscIdAsc(conversationId).stream()
                 .map(MessageResponse::fromEntity)
@@ -66,14 +80,23 @@ public class MessageServiceImpl implements MessageService {
     @Override
     @Transactional
     public void delete(Long id) {
+        User currentUser = SecurityUtils.getCurrentUser();
+
         log.info("Soft deleting message with ID: {}", id);
 
         Message entity = repository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(MESSAGE_NOT_FOUND + id));
+                .orElseThrow(() -> new ResourceNotFoundException(MESSAGE_NOT_FOUND));
+
+        requireConversationOwnedByCurrentUser(entity.getConversationId(), currentUser.getId());
 
         entity.setIsActive(false);
         repository.save(entity);
 
         log.info("Soft deleted message with ID: {}", id);
+    }
+
+    private void requireConversationOwnedByCurrentUser(Long conversationId, Long currentUserId) {
+        conversationRepository.findByIdAndUserId(conversationId, currentUserId)
+                .orElseThrow(() -> new ResourceNotFoundException(MESSAGE_NOT_FOUND));
     }
 }

--- a/bossbot/src/main/java/com/example/bossbot/security/LocalMethodSecurityConfig.java
+++ b/bossbot/src/main/java/com/example/bossbot/security/LocalMethodSecurityConfig.java
@@ -1,0 +1,23 @@
+package com.example.bossbot.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * Configuration class for enabling method security specifically for the "local" profile.
+ *
+ * This configuration class is activated when the application is running with the "local" Spring profile.
+ * It controls the method security settings, disabling pre/post annotations for method security by
+ * setting `prePostEnabled` to false.
+ *
+ * Annotations:
+ * - {@code @Profile("local")}: Ensures that this configuration is only loaded for the "local" profile.
+ * - {@code @Configuration}: Marks this class as a source of bean definitions for the application context.
+ * - {@code @EnableMethodSecurity}: Configures method-level security with the specified settings.
+ */
+@Profile("local")
+@Configuration
+@EnableMethodSecurity(prePostEnabled = false)
+public class LocalMethodSecurityConfig {
+}

--- a/bossbot/src/main/java/com/example/bossbot/security/SecurityConfig.java
+++ b/bossbot/src/main/java/com/example/bossbot/security/SecurityConfig.java
@@ -141,12 +141,10 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers("/auth/dev/**", "/", "/error", "/oauth2/**", "/login/oauth2/code/**", "/auth/login/success")
                                 .permitAll()
-                                // Actuator endpoints - allow unauthenticated for health checks and Prometheus scraping
                                 // In production, we can consider IP allowlisting at reverse proxy/firewall level
                                 .requestMatchers("/actuator/health", "/actuator/prometheus", "/actuator/info").permitAll()
                                 // Local dev endpoints - allow checking security status
                                 .requestMatchers("/api/v1/security-status").permitAll()
-                                // TODO: add other public API EP if any, no admin EP now, but block just in case if someone adds them
                                 .requestMatchers("/api/v1/admin/**").hasRole(RoleName.ADMIN.name())
                                 .requestMatchers("/api/v1/**").hasAnyRole(RoleName.USER.name(), RoleName.ADMIN.name())
                                 // All other API requests require authentication

--- a/bossbot/src/main/java/com/example/bossbot/security/SecurityConfig.java
+++ b/bossbot/src/main/java/com/example/bossbot/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.bossbot.security;
 
+import com.example.bossbot.role.RoleName;
 import com.example.bossbot.user.User;
 import com.example.bossbot.user.UserRepository;
 import jakarta.servlet.http.Cookie;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -58,6 +60,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final ClientRegistrationRepository clientRegistrationRepository;
@@ -130,18 +133,22 @@ public class SecurityConfig {
                 .requestCache(RequestCacheConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> {
+                    // TODO:: permitAll - remove in production
                     if (permitAll) {
                         auth.anyRequest().permitAll();
                     } else {
                         auth
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                                .requestMatchers("/", "/error", "/oauth2/**", "/login/oauth2/code/**", "/auth/login/success")
+                                .requestMatchers("/auth/dev/**", "/", "/error", "/oauth2/**", "/login/oauth2/code/**", "/auth/login/success")
                                 .permitAll()
                                 // Actuator endpoints - allow unauthenticated for health checks and Prometheus scraping
                                 // In production, we can consider IP allowlisting at reverse proxy/firewall level
                                 .requestMatchers("/actuator/health", "/actuator/prometheus", "/actuator/info").permitAll()
                                 // Local dev endpoints - allow checking security status
                                 .requestMatchers("/api/v1/security-status").permitAll()
+                                // TODO: add other public API EP if any, no admin EP now, but block just in case if someone adds them
+                                .requestMatchers("/api/v1/admin/**").hasRole(RoleName.ADMIN.name())
+                                .requestMatchers("/api/v1/**").hasAnyRole(RoleName.USER.name(), RoleName.ADMIN.name())
                                 // All other API requests require authentication
                                 .anyRequest().authenticated();
                     }

--- a/bossbot/src/main/java/com/example/bossbot/stampanswer/controller/StampAnswerController.java
+++ b/bossbot/src/main/java/com/example/bossbot/stampanswer/controller/StampAnswerController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,7 @@ public class StampAnswerController {
      * Create a new stamp answer
      * POST /api/v1/stamp-answers
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create a new stamp answer")
     @ApiResponse(responseCode = "201", description = "Stamp answer created successfully")
     @ApiResponse(responseCode = "400", description = "Invalid request body")
@@ -48,6 +50,7 @@ public class StampAnswerController {
      * Get stamp answer by ID
      * GET /api/v1/stamp-answers/{id}
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get a stamp answer by ID")
     @ApiResponse(responseCode = "200", description = "Stamp answer found")
     @ApiResponse(responseCode = "404", description = "Stamp answer not found")
@@ -63,6 +66,7 @@ public class StampAnswerController {
      * Get all stamp answers
      * GET /api/v1/stamp-answers
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get all stamp answers")
     @ApiResponse(responseCode = "200", description = "Stamp answers returned")
     @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -80,6 +84,7 @@ public class StampAnswerController {
      * Search stamp answers by question or keywords
      * GET /api/v1/stamp-answers/search?q={searchTerm}
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Search stamp answers by question or keywords")
     @ApiResponse(responseCode = "200", description = "Search results returned")
     @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -95,6 +100,7 @@ public class StampAnswerController {
      * GET /api/v1/stamp-answers/by-question?q={question}
      * Returns 404 if no matching active stamp answer found
      */
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     @Operation(summary = "Get answer by exact question match")
     @ApiResponse(responseCode = "200", description = "Stamp answer found")
     @ApiResponse(responseCode = "404", description = "No matching stamp answer found")
@@ -114,6 +120,7 @@ public class StampAnswerController {
      * Get most used stamp answers
      * GET /api/v1/stamp-answers/most-used
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Get most used stamp answers")
     @ApiResponse(responseCode = "200", description = "Most used stamp answers returned")
     @ApiResponse(responseCode = "500", description = "Internal server error")
@@ -128,6 +135,7 @@ public class StampAnswerController {
      * Update stamp answer
      * PUT /api/v1/stamp-answers/{id}
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Update a stamp answer")
     @ApiResponse(responseCode = "200", description = "Stamp answer updated successfully")
     @ApiResponse(responseCode = "404", description = "Stamp answer not found")
@@ -146,6 +154,7 @@ public class StampAnswerController {
      * Delete (deactivate) stamp answer
      * DELETE /api/v1/stamp-answers/{id}
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Delete (deactivate) a stamp answer")
     @ApiResponse(responseCode = "204", description = "Stamp answer deleted successfully")
     @ApiResponse(responseCode = "404", description = "Stamp answer not found")
@@ -161,6 +170,7 @@ public class StampAnswerController {
      * Record usage of a stamp answer
      * POST /api/v1/stamp-answers/{id}/usage
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Record usage of a stamp answer")
     @ApiResponse(responseCode = "200", description = "Usage recorded successfully")
     @ApiResponse(responseCode = "404", description = "Stamp answer not found")

--- a/bossbot/src/main/java/com/example/bossbot/user/AccountController.java
+++ b/bossbot/src/main/java/com/example/bossbot/user/AccountController.java
@@ -1,38 +1,85 @@
 package com.example.bossbot.user;
 
 
+import com.example.bossbot.role.Role;
 import com.example.bossbot.role.RoleName;
 import com.example.bossbot.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * REST controller for managing user account information.
  * Provides endpoints for retrieving details of the currently authenticated user.
  * SecurityUtils throws ResponseStatusException if occurs, ApiExceptionHandler catches it globally
+ * If user does not have role yet, default to USER
  */
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/account")
 @RequiredArgsConstructor
 public class AccountController {
+//    private final UserRepository userRepository;
     public record MeResponse(String email, String name, RoleName roleName, Long discordId) {
     }
+
+//    public record RegisterRequest(boolean acceptTerms) {
+//    }
 
     @GetMapping
     @Operation(summary = "Get current user account", description = "Returns the currently authenticated user")
     @ApiResponse(responseCode = "200", description = "Successfully retrieved account info")
     @ApiResponse(responseCode = "401", description = "Not authenticated")
-    public MeResponse me() {
-        User user = SecurityUtils.getCurrentUser();
-        return new MeResponse(
-                user.getEmail(),
-                user.getName(),
-                user.getRole() != null ? user.getRole().getRoleName() : null,
-                user.getDiscordId()
-        );
+    public ResponseEntity<MeResponse> me() {
+        try {
+            User user = SecurityUtils.getCurrentUser();
+            return ResponseEntity.ok (new MeResponse(
+                    user.getEmail(),
+                    user.getName(),
+                    user.getRole() != null ? user.getRole().getRoleName() : null,
+                    user.getDiscordId()
+            ));
+        } catch (ResponseStatusException e) {
+            return ResponseEntity.status(e.getStatusCode()).build();
+        } catch (Exception e) {
+            // Log unexpected errors for debugging
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to retrieve account information: " + e.getMessage(),
+                    e);
+        }
     }
+
+//    @PostMapping("/register")
+//    @Transactional
+//    public ResponseEntity<Void> register(@RequestBody RegisterRequest req) {
+//        try {
+//            if (!req.acceptTerms())
+//                return ResponseEntity.badRequest().build();
+//
+//            User user = SecurityUtils.getCurrentUser();
+//
+//            // Set org and role if needed (idempotent: do nothing if already set)
+//            if (user.getRole() == null) {
+//                user.setRole(Role.builder().roleName(RoleName.USER).build());
+//                userRepository.save(user);
+//            }
+//
+//            // If later you click agree on register, then re-issue JWT token here.
+//            return ResponseEntity.noContent().build();
+//        } catch (ResponseStatusException e) {
+//            throw e; // Re-throw to be handled by exception handler
+//        } catch (Exception e) {
+//            throw new ResponseStatusException(
+//                    org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
+//                    "Failed to complete onboarding: " + e.getMessage(),
+//                    e);
+//        }
+//    }
 }

--- a/bossbot/src/main/java/com/example/bossbot/user/AccountController.java
+++ b/bossbot/src/main/java/com/example/bossbot/user/AccountController.java
@@ -55,31 +55,4 @@ public class AccountController {
                     e);
         }
     }
-
-//    @PostMapping("/register")
-//    @Transactional
-//    public ResponseEntity<Void> register(@RequestBody RegisterRequest req) {
-//        try {
-//            if (!req.acceptTerms())
-//                return ResponseEntity.badRequest().build();
-//
-//            User user = SecurityUtils.getCurrentUser();
-//
-//            // Set org and role if needed (idempotent: do nothing if already set)
-//            if (user.getRole() == null) {
-//                user.setRole(Role.builder().roleName(RoleName.USER).build());
-//                userRepository.save(user);
-//            }
-//
-//            // If later you click agree on register, then re-issue JWT token here.
-//            return ResponseEntity.noContent().build();
-//        } catch (ResponseStatusException e) {
-//            throw e; // Re-throw to be handled by exception handler
-//        } catch (Exception e) {
-//            throw new ResponseStatusException(
-//                    org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,
-//                    "Failed to complete onboarding: " + e.getMessage(),
-//                    e);
-//        }
-//    }
 }

--- a/bossbot/src/main/java/com/example/bossbot/user/UserController.java
+++ b/bossbot/src/main/java/com/example/bossbot/user/UserController.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@PreAuthorize("hasRole('ADMIN')")
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/v1/users")

--- a/bossbot/src/main/resources/application-docker.properties
+++ b/bossbot/src/main/resources/application-docker.properties
@@ -1,7 +1,7 @@
 # Docker profile - for local development with Docker Compose
 # For production Docker deployment, use 'production' profile instead (SPRING_PROFILES_ACTIVE=production)
 # Database configuration comes from environment variables (docker-compose.yaml)
-spring.datasource.url=${SPRING_DOCKER_DATASOURCE_URL}
+spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 

--- a/bossbot/src/main/resources/application-docker.properties
+++ b/bossbot/src/main/resources/application-docker.properties
@@ -1,7 +1,7 @@
 # Docker profile - for local development with Docker Compose
 # For production Docker deployment, use 'production' profile instead (SPRING_PROFILES_ACTIVE=production)
 # Database configuration comes from environment variables (docker-compose.yaml)
-spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.url=${SPRING_DOCKER_DATASOURCE_URL}
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 
@@ -34,4 +34,7 @@ app.frontend.url=${APP_FRONTEND_URL:http://localhost:5173}
 
 # NB! Set true for docker local dev. to disable authentication (no Google login needed) for easier testing
 # IMPORTANT: Set to false in production!
-app.security.permit-all=true
+app.security.permit-all=false
+
+# Manage e-mails for admin users (add admin e-mail in env-variables, comma-separated)
+app.auth.admin-bootstrap-emails=${ADMIN_BOOTSTRAP_EMAILS:}

--- a/bossbot/src/main/resources/application-production.properties
+++ b/bossbot/src/main/resources/application-production.properties
@@ -65,3 +65,6 @@ management.metrics.enable.hikaricp=true
 management.metrics.enable.jvm=true
 management.metrics.enable.logback=true
 management.metrics.enable.system=true
+
+# Manage e-mails for admin users (add admin e-mail in env-variables, comma-separated)
+app.auth.admin-bootstrap-emails=${ADMIN_BOOTSTRAP_EMAILS:}


### PR DESCRIPTION
67 - BE Authorization implementation. Secure authorization and chat ownership rules

## Summary:
#67 implements: BE authorization part. Secure authorization and chat ownership rules

## Changes:
- Restrict users and admins to their own conversations and messages
- Add ownership checks for message creation, listing, reading, and deletion
- Ensure conversation queries return only the current user's conversations
- Restrict admin panel endpoints to ADMIN users
- Prevent regular users from accessing user-management endpoints
- Allow USER access only to chat/conversation flows and required matching lookups
- Keep banned word and stamp answer management admin-only
- Apply admin-managed banned words and stamp answers globally for all users
- Propagate WebSocket authentication into async chat processing

## Important:

- **NB! Admins can be currently added in .env file, so you need to add ADMIN EMAIL into .env file (see .env-example):**

ADMIN_BOOTSTRAP_EMAILS=adminemail@gmail.com,admin2email@gmail.com

- **and in application-production.properties:**

app.auth.admin-bootstrap-emails=${ADMIN_BOOTSTRAP_EMAILS:}

- **and in application-docker.properties:**

app.auth.admin-bootstrap-emails=${ADMIN_BOOTSTRAP_EMAILS:}

- **NB!** The authorization works with DOCKER PROFILE. If you add above mentioned env-variable to production profile, it should work with production profile as well. 

- **NB!** It may break _local_  non-login flow. I added sth to keep it working w/o login locally, but it may not work, Have not tested with localhost local profile.

## Related to:
Closes: #67 

